### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,10 @@ PINECONE_API_KEY=your-api-key
 
 # Cohere - Get key at https://dashboard.cohere.com/api-keys
 COHERE_API_KEY=your-api-key
+
+# Astraflow (UCloud) - OpenAI-compatible platform supporting 200+ models
+# Global endpoint - Get key at https://astraflow.ucloud-global.com
+ASTRAFLOW_API_KEY=your-api-key
+
+# Astraflow (UCloud) - China endpoint - Get key at https://astraflow.ucloud.cn
+ASTRAFLOW_CN_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -192,7 +192,14 @@ Begin with `[1]_rag_setup_overview.ipynb` to get familiar with the setup process
    PINECONE_API_HOST="your-host-url"
    PINECONE_API_KEY="your-api-key"
 
-   # Cohere - Get key at https://dashboard.cohere.com/api-keys
+   # Astraflow (UCloud) - OpenAI-compatible, 200+ models
+   # Global endpoint - Get key at https://astraflow.ucloud-global.com
+   ASTRAFLOW_API_KEY="your-api-key"
+
+   # Astraflow (UCloud) - China endpoint - Get key at https://astraflow.ucloud.cn
+   ASTRAFLOW_CN_API_KEY="your-api-key"
+
+      # Cohere - Get key at https://dashboard.cohere.com/api-keys
    COHERE_API_KEY=your-api-key
    ```
 


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) by UCloud as a supported LLM provider.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it is OpenAI-compatible, **no new SDK or dependency is needed** — users simply pass `base_url` and `api_key` to the existing `ChatOpenAI` constructor:

```python
from langchain_openai import ChatOpenAI

# Global endpoint
llm = ChatOpenAI(
    model_name="gpt-4o",           # or any of the 200+ supported models
    openai_api_key=os.getenv("ASTRAFLOW_API_KEY"),
    openai_api_base="https://api-us-ca.umodelverse.ai/v1",
    temperature=0.1,
)

# China endpoint
llm = ChatOpenAI(
    model_name="gpt-4o",
    openai_api_key=os.getenv("ASTRAFLOW_CN_API_KEY"),
    openai_api_base="https://api.modelverse.cn/v1",
    temperature=0.1,
)
```

## Changes

- **`.env.example`** — added `ASTRAFLOW_API_KEY` (global) and `ASTRAFLOW_CN_API_KEY` (China endpoint) with sign-up URLs
- **`README.md`** — added Astraflow keys to the "Set Up Environment Variables" section so users know to populate them

## Provider info

| | Global | China |
|---|---|---|
| **Website** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |
| **API key** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |
| **Base URL** | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
| **Env var** | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |
